### PR TITLE
feat: Added .editorconfig file following Linux's example

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false
+
+[*.{json}]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = false
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 ./application/app/dist
 ./application/app/bower_components
+.vscode/
 
 # app/bower_components
 # app/dist

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    // editorconfig plugin
+    "EditorConfig.EditorConfig"
+  ]
+}


### PR DESCRIPTION
And added editorconfig plugin suggestion on extensions.json for vscode users. Vscode does not process editorconfig files natively

closes #10 